### PR TITLE
Validering av basePath

### DIFF
--- a/src/main/java/no/fintlabs/operator/SsoSpec.java
+++ b/src/main/java/no/fintlabs/operator/SsoSpec.java
@@ -8,4 +8,12 @@ public class SsoSpec implements FlaisSpec {
     private String basePath = "";
     private String hostname;
     private String loggingLevel = "info";
+
+    public void setBasePath(String basePath) {
+        while (basePath.endsWith("/")) {
+            basePath = basePath.substring(0, basePath.length() - 1);
+        }
+        this.basePath = basePath;
+    }
+
 }

--- a/src/main/java/no/fintlabs/operator/SsoSpec.java
+++ b/src/main/java/no/fintlabs/operator/SsoSpec.java
@@ -5,7 +5,7 @@ import no.fintlabs.FlaisSpec;
 
 @Data
 public class SsoSpec implements FlaisSpec {
-    private String basePath;
+    private String basePath = "";
     private String hostname;
     private String loggingLevel = "info";
 }

--- a/src/test/groovy/no/fintlabs/TransformerSpec.groovy
+++ b/src/test/groovy/no/fintlabs/TransformerSpec.groovy
@@ -62,4 +62,16 @@ class TransformerSpec extends Specification {
         deployment.getSpec().getTemplate().getSpec().getContainers().get(0).getImage() == "ghcr.io/fintlabs/flais-auth-forward-service:latest"
 
     }
+
+    def "BasePath should not end with a slash"() {
+        given:
+        def spec = new SsoSpec()
+
+        when:
+        spec.setBasePath("some/base/path//")
+
+        then:
+        spec.getBasePath() == "some/base/path"
+    }
+
 }


### PR DESCRIPTION
Ssoerator feiler uten basePath, selv om "/_oauth" legges til automatisk. Feil skjer også med "/" som basePath, da får vi "//_oauth". basePath er nå satt som tom streng for å unngå nullPointer exception. Jeg har korrigert dette og lagt til en test for fremtidig verifisering.