### PR TITLE
Add Traefik v3 CRDs

### DIFF
--- a/kustomize/base/clusterrole.yaml
+++ b/kustomize/base/clusterrole.yaml
@@ -29,6 +29,7 @@ rules:
   - apiGroups:
       - fintlabs.no
       - traefik.containo.us
+      - traefik.io
     resources:
       - "*"
 #      - namoauthclientapplicationresources

--- a/src/main/java/no/fintlabs/operator/traefik/ingress/IngressRouteV3Crd.java
+++ b/src/main/java/no/fintlabs/operator/traefik/ingress/IngressRouteV3Crd.java
@@ -1,0 +1,18 @@
+package no.fintlabs.operator.traefik.ingress;
+
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Kind;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+@Group("traefik.io")
+@Version("v1alpha1")
+@Kind("IngressRoute")
+public class IngressRouteV3Crd extends CustomResource<IngressRouteSpec, Void> implements Namespaced {
+
+    @Override
+    protected IngressRouteSpec initSpec() {
+        return new IngressRouteSpec();
+    }
+}

--- a/src/main/java/no/fintlabs/operator/traefik/ingress/IngressRouteV3DependentResource.java
+++ b/src/main/java/no/fintlabs/operator/traefik/ingress/IngressRouteV3DependentResource.java
@@ -1,0 +1,47 @@
+package no.fintlabs.operator.traefik.ingress;
+
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import no.fintlabs.FlaisKubernetesDependentResource;
+import no.fintlabs.FlaisWorkflow;
+import no.fintlabs.Transformer;
+import no.fintlabs.operator.LabelFactory;
+import no.fintlabs.operator.SsoCrd;
+import no.fintlabs.operator.SsoSpec;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class IngressRouteV3DependentResource extends FlaisKubernetesDependentResource<IngressRouteV3Crd, SsoCrd, SsoSpec> {
+
+    private final Transformer transformer;
+
+    public IngressRouteV3DependentResource(FlaisWorkflow<SsoCrd, SsoSpec> workflow, KubernetesClient kubernetesClient, Transformer transformer) {
+        super(IngressRouteV3Crd.class, workflow, kubernetesClient);
+        this.transformer = transformer;
+    }
+
+    @Override
+    protected IngressRouteV3Crd desired(SsoCrd primary, Context<SsoCrd> context) {
+
+        try {
+            MixedOperation<IngressRouteV3Crd, KubernetesResourceList<IngressRouteV3Crd>, Resource<IngressRouteV3Crd>> client
+                    = getKubernetesClient().resources(IngressRouteV3Crd.class);
+            IngressRouteV3Crd ingressRouteCrd = client
+                    .load(transformer.transform(primary, "k8s/ingress-route-v3.yaml"))
+                    .get();
+
+            ingressRouteCrd.getMetadata().setNamespace(primary.getMetadata().getNamespace());
+            ingressRouteCrd.getMetadata().setName(primary.getMetadata().getName());
+            LabelFactory.updateRecommendedLabels(ingressRouteCrd, primary);
+
+            return ingressRouteCrd;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/no/fintlabs/operator/traefik/middleware/AuthForwardMiddlewareV3Crd.java
+++ b/src/main/java/no/fintlabs/operator/traefik/middleware/AuthForwardMiddlewareV3Crd.java
@@ -1,0 +1,17 @@
+package no.fintlabs.operator.traefik.middleware;
+
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Kind;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+@Group("traefik.io")
+@Version("v1alpha1")
+@Kind("Middleware")
+public class AuthForwardMiddlewareV3Crd extends CustomResource<AuthForwardMiddlewareSpec, Void> implements Namespaced {
+    @Override
+    protected AuthForwardMiddlewareSpec initSpec() {
+        return new AuthForwardMiddlewareSpec();
+    }
+}

--- a/src/main/java/no/fintlabs/operator/traefik/middleware/AuthForwardMiddlewareV3DependentResource.java
+++ b/src/main/java/no/fintlabs/operator/traefik/middleware/AuthForwardMiddlewareV3DependentResource.java
@@ -1,0 +1,54 @@
+package no.fintlabs.operator.traefik.middleware;
+
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import lombok.extern.slf4j.Slf4j;
+import no.fintlabs.FlaisKubernetesDependentResource;
+import no.fintlabs.FlaisWorkflow;
+import no.fintlabs.Transformer;
+import no.fintlabs.operator.LabelFactory;
+import no.fintlabs.operator.SsoCrd;
+import no.fintlabs.operator.SsoSpec;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class AuthForwardMiddlewareV3DependentResource extends FlaisKubernetesDependentResource<AuthForwardMiddlewareV3Crd, SsoCrd, SsoSpec> {
+
+
+    private final Transformer transformer;
+
+    public AuthForwardMiddlewareV3DependentResource(FlaisWorkflow<SsoCrd, SsoSpec> workflow, KubernetesClient kubernetesClient, Transformer transformer) {
+        super(AuthForwardMiddlewareV3Crd.class, workflow, kubernetesClient);
+        this.transformer = transformer;
+    }
+
+
+    @Override
+    protected AuthForwardMiddlewareV3Crd desired(SsoCrd primary, Context<SsoCrd> context) {
+
+        try {
+            MixedOperation<AuthForwardMiddlewareV3Crd, KubernetesResourceList<AuthForwardMiddlewareV3Crd>, Resource<AuthForwardMiddlewareV3Crd>> resources
+                    = getKubernetesClient().resources(AuthForwardMiddlewareV3Crd.class);
+
+            AuthForwardMiddlewareV3Crd middleware = resources
+                    .load(transformer.transform(primary, "k8s/middleware-v3.yaml"))
+                    .get();
+
+            middleware.getMetadata().setNamespace(primary.getMetadata().getNamespace());
+            log.info("Desired Traefik v3 middleware:");
+            log.info(middleware.toString());
+            LabelFactory.updateRecommendedLabels(middleware, primary);
+
+            return middleware;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+}

--- a/src/main/resources/k8s/ingress-route-v3.yaml
+++ b/src/main/resources/k8s/ingress-route-v3.yaml
@@ -1,0 +1,14 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ name }}
+  namespace: {{ namespace }}
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: Host(`{{ hostname }}`) && PathPrefix(`{{ basePath }}{{ oauthPath }}`)
+      kind: Rule
+      services:
+        - name: {{ name }}
+          port: 8080

--- a/src/main/resources/k8s/middleware-v3.yaml
+++ b/src/main/resources/k8s/middleware-v3.yaml
@@ -1,0 +1,11 @@
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ name }}
+  namespace: {{ namespace }}
+spec:
+  forwardAuth:
+    address: http://{{ name }}.{{ namespace }}:8080{{ basePath }}{{ oauthPath }}
+    authResponseHeaders:
+      - Authorization
+    trustForwardHeader: true

--- a/src/test/groovy/no/fintlabs/TransformerSpec.groovy
+++ b/src/test/groovy/no/fintlabs/TransformerSpec.groovy
@@ -64,4 +64,27 @@ class TransformerSpec extends Specification {
 
     }
 
+    def "When transforming Traefik manifests they should use v2 and v3 api groups"() {
+        given:
+        def crd = new SsoCrd()
+        def spec = new SsoSpec()
+        crd.getMetadata().setName("test")
+        crd.getMetadata().setNamespace("test")
+        spec.setBasePath("basePath")
+        spec.setHostname("hostname")
+        crd.setSpec(spec)
+
+        when:
+        def ingressRouteV2 = transformer.transform(crd, "k8s/ingress-route.yaml").text
+        def middlewareV2 = transformer.transform(crd, "k8s/middleware.yaml").text
+        def ingressRouteV3 = transformer.transform(crd, "k8s/ingress-route-v3.yaml").text
+        def middlewareV3 = transformer.transform(crd, "k8s/middleware-v3.yaml").text
+
+        then:
+        ingressRouteV2.contains("apiVersion: traefik.containo.us/v1alpha1")
+        middlewareV2.contains("apiVersion: traefik.containo.us/v1alpha1")
+        ingressRouteV3.contains("apiVersion: traefik.io/v1alpha1")
+        middlewareV3.contains("apiVersion: traefik.io/v1alpha1")
+    }
+
 }


### PR DESCRIPTION
Adds Traefik v3 `IngressRoute` and `Middleware` resources alongside the existing v2 resources so both controllers can run during migration.

The operator now has CRD classes and manifest templates for the `traefik.io/v1alpha1` API group, while RBAC allows managing both Traefik API groups.

Transformer coverage verifies that v2 manifests keep `traefik.containo.us/v1alpha1` and v3 manifests use `traefik.io/v1alpha1`.

Validated with `./gradlew test`.