### PR TITLE
build: pin distroless runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ USER root
 COPY . .
 RUN gradle --no-daemon build
 
-FROM gcr.io/distroless/java17
+FROM gcr.io/distroless/java17-debian13:latest@sha256:cf7080f552165a1b5586349fcce84a62aa1ae9ac1a6811f9c515accbe9dcc125
 ENV JAVA_TOOL_OPTIONS -XX:+ExitOnOutOfMemoryError
 COPY --from=builder /home/gradle/build/libs/*.jar /data/app.jar
 CMD ["/data/app.jar"]


### PR DESCRIPTION
Pins the Java 17 distroless runtime image in the Dockerfile to the explicit Debian 13 tag and current digest.

This lets Dependabot monitor and refresh the runtime image instead of leaving the untagged base image outside Docker update coverage. Validation: reviewed `git diff origin/main...` and confirmed the pinned image resolves with `docker buildx imagetools inspect`.